### PR TITLE
Fix for combobox popup and tooltip  issues

### DIFF
--- a/openjdk6-b22/jdk/src/share/classes/javax/swing/ToolTipManager.java
+++ b/openjdk6-b22/jdk/src/share/classes/javax/swing/ToolTipManager.java
@@ -211,6 +211,31 @@ public class ToolTipManager extends MouseAdapter implements MouseMotionListener 
         return exitTimer.getInitialDelay();
     }
 
+    /**
+     * Tries to find GraphicsConfiguration
+     * that contains the mouse cursor position.
+     * Can return null.
+     */
+    private GraphicsConfiguration getCurrentGraphicsConfiguration(
+            Point popupLocation) {
+        GraphicsConfiguration gc = null;
+        GraphicsEnvironment ge =
+            GraphicsEnvironment.getLocalGraphicsEnvironment();
+        GraphicsDevice[] gd = ge.getScreenDevices();
+        for(int i = 0; i < gd.length; i++) {
+            if(gd[i].getType() == GraphicsDevice.TYPE_RASTER_SCREEN) {
+                GraphicsConfiguration dgc =
+                    gd[i].getDefaultConfiguration();
+                if(dgc.getBounds().contains(popupLocation)) {
+                    gc = dgc;
+                    break;
+                }
+            }
+        }
+        return gc;
+    }
+
+
     void showTipWindow() {
         if(insideComponent == null || !insideComponent.isShowing())
             return;
@@ -227,7 +252,9 @@ public class ToolTipManager extends MouseAdapter implements MouseMotionListener 
             Point screenLocation = insideComponent.getLocationOnScreen();
             Point location = new Point();
             GraphicsConfiguration gc;
-            gc = insideComponent.getGraphicsConfiguration();
+            gc = getCurrentGraphicsConfiguration(screenLocation);
+            if (gc == null)
+              gc = insideComponent.getGraphicsConfiguration();
             Rectangle sBounds = gc.getBounds();
             Insets screenInsets = Toolkit.getDefaultToolkit()
                                              .getScreenInsets(gc);

--- a/openjdk6-b22/jdk/src/share/classes/javax/swing/plaf/basic/BasicComboPopup.java
+++ b/openjdk6-b22/jdk/src/share/classes/javax/swing/plaf/basic/BasicComboPopup.java
@@ -1232,11 +1232,9 @@ public class BasicComboPopup extends JPopupMenu implements ComboPopup {
             screenBounds = new Rectangle(p, toolkit.getScreenSize());
         }
 
+        if (ph > screenBounds.height && screenBounds.height > 500)
+            ph = screenBounds.height - 1;
         Rectangle rect = new Rectangle(px,py,pw,ph);
-        if (py+ph > screenBounds.y+screenBounds.height
-            && ph < screenBounds.height) {
-            rect.y = -rect.height;
-        }
         return rect;
     }
 


### PR DESCRIPTION
Incorrect negative Y position of popup returned for some combination of popup size and screen size;
Tooltip is displayed on primary monitor for components located on secondary.